### PR TITLE
Fixing project configuration and build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is a wrapper Java API around the Eve [Online Swagger Interface](
 
 * Download this repository
 
-* Run `gradle build`.
+* Run `gradlew build`.
 
 * Look at `org.devfleet.esi.EsiClient`. You should know what to do.
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 [![Build Status](https://travis-ci.org/evanova/eve-esi-java.svg?branch=master)](https://travis-ci.org/evanova/eve-esi-java)
 
-# Eve Online Swagger Interface in Java
+# EVE Online Swagger Interface in Java
 
-This repository is a wrapper Java API around the Eve [Online Swagger Interface](https://esi.tech.ccp.is/latest/#/) (ESI).
+This repository is a wrapper Java API around the [EVE Swagger Interface](https://esi.tech.ccp.is/latest/#/) (ESI).
 
 ## Quick Start
 
-* Download this repository
+*   Download this repository
 
-* Run `gradlew build`.
+*   Run
+    -   On Linux/Mac: `./gradlew build`
+    -   On Windows:   `gradlew.bat build`
 
-* Look at `org.devfleet.esi.EsiClient`. You should know what to do.
+*   Look at `org.devfleet.esi.EsiClient`. You should know what to do.
 
 ## Status
 
 This API is in a very early stage and everyone is welcomed to fill the gaps.
 Also note that since it builds on ESI directly, build will break on each ESI change.
 
-##Authors
+## Authors
 
 evanova.mobile@gmail.com (in-game: Evanova Android) (reddit: /u/evanova)
-

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -22,12 +22,12 @@ def generated = "$projectDir/generated/"
 sourceSets {
     main {
         java {
-            srcDirs += "$generated/src/main"
+            srcDirs += "$generated/src/main/java"
         }
     }
     test {
         java {
-            srcDirs += "$generated/src/test"
+            srcDirs += "$generated/src/test/java"
         }
     }
 }


### PR DESCRIPTION
Changes to fix issues with Eclipse and the generated sources, Eclipse was complaining that the packages names were not matching the folder structure. Just updated the root folder for the generated sources on Gradle build.

Also updated the README to point to the wrapper script instead of a global installation.